### PR TITLE
OZ-462: Ozone distro to repackage the O3 frontend

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -266,30 +266,6 @@
           </execution>
 
           <execution>
-            <!-- Copy scripts -->
-            <id>Copy local scripts</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>
-                ${project.build.directory}/${project.artifactId}-${project.version}/scripts</outputDirectory>
-              <overwrite>true</overwrite>
-              <resources>
-                <resource>
-                  <directory>${project.basedir}/scripts</directory>
-                  <includes>
-                    <include>
-                      openmrs/frontend_assembly/build-openmrs-frontend.groovy
-                    </include>
-                  </includes>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-
-          <execution>
             <!-- Copy OpenMRS modules -->
             <id>Copy OpenMRS modules</id>
             <phase>prepare-package</phase>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -197,7 +197,7 @@
             </goals>
             <configuration>
               <excludeTransitive>true</excludeTransitive>
-              <outputDirectory>${project.build.directory}/referenceapplication-frontend</outputDirectory>
+              <outputDirectory>${project.build.directory}/openmrs_frontend</outputDirectory>
               <includeArtifactIds>referenceapplication-frontend</includeArtifactIds>
             </configuration>
           </execution>
@@ -260,6 +260,30 @@
               <resources>
                 <resource>
                   <directory>${project.basedir}/data</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+
+          <execution>
+            <!-- Copy scripts -->
+            <id>Copy local scripts</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>
+                ${project.build.directory}/${project.artifactId}-${project.version}/scripts</outputDirectory>
+              <overwrite>true</overwrite>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/scripts</directory>
+                  <includes>
+                    <include>
+                      openmrs/frontend_assembly/build-openmrs-frontend.groovy
+                    </include>
+                  </includes>
                 </resource>
               </resources>
             </configuration>
@@ -330,11 +354,15 @@
 
           <execution>
             <id>Rename spa-assemble-config.json to reference-application-spa-assemble-config.json</id>
-            <phase>process-resources</phase>
+            <phase>generate-resources</phase>
             <configuration>
               <target>
-                <move todir="${project.build.directory}/${project.artifactId}-${project.version}/configs/openmrs/frontend_assembly">
-                  <fileset dir="${project.build.directory}/referenceapplication-frontend" />
+                <copy todir="${project.build.directory}/${project.artifactId}-${project.version}/configs/openmrs/frontend_assembly">
+                  <fileset dir="${project.build.directory}/openmrs_frontend" />
+                  <mapper from="spa-assemble-config.json" to="reference-application-spa-assemble-config.json" type="regexp" />
+                </copy>
+                <move todir="${project.build.directory}/openmrs_frontend">
+                  <fileset dir="${project.build.directory}/openmrs_frontend" />
                   <mapper from="spa-assemble-config.json" to="reference-application-spa-assemble-config.json" type="regexp" />
                 </move>
               </target>
@@ -393,6 +421,25 @@
             <goals>
               <goal>run</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>Build OpenMRS Frontend</id>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <phase>process-resources</phase>
+            <configuration>
+              <scripts>
+                <script>file://${project.basedir}/../scripts/openmrs/frontend_assembly/build-openmrs-frontend.groovy</script>
+              </scripts>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -30,7 +30,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Dependency versions -->
-    <referenceapplicationDistroVersion>3.0.0-beta.16</referenceapplicationDistroVersion>
+    <referenceapplicationDistroVersion>3.0.0-SNAPSHOT</referenceapplicationDistroVersion>
     <odoo_initializerVersion>2.1.0</odoo_initializerVersion>
     <commonreportsVersion>1.4.0-SNAPSHOT</commonreportsVersion>
     <patientsummaryVersion>2.2.0</patientsummaryVersion>
@@ -50,6 +50,13 @@
     <dependency>
       <groupId>org.openmrs.distro</groupId>
       <artifactId>referenceapplication-distro</artifactId>
+      <type>zip</type>
+      <version>${referenceapplicationDistroVersion}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.openmrs.distro</groupId>
+      <artifactId>referenceapplication-frontend</artifactId>
       <type>zip</type>
       <version>${referenceapplicationDistroVersion}</version>
     </dependency>
@@ -98,7 +105,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.2.0</version>
         <executions>
           <execution>
             <id>Copy Odoo Initializer add-on</id>
@@ -183,6 +189,18 @@
             </configuration>
           </execution>
 
+          <execution>
+            <id>Unpack OpenMRS Ref App frontend configuration</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>unpack-dependencies</goal>
+            </goals>
+            <configuration>
+              <excludeTransitive>true</excludeTransitive>
+              <outputDirectory>${project.build.directory}/referenceapplication-frontend</outputDirectory>
+              <includeArtifactIds>referenceapplication-frontend</includeArtifactIds>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 
@@ -311,6 +329,22 @@
           </execution>
 
           <execution>
+            <id>Rename spa-assemble-config.json to reference-application-spa-assemble-config.json</id>
+            <phase>process-resources</phase>
+            <configuration>
+              <target>
+                <move todir="${project.build.directory}/${project.artifactId}-${project.version}/configs/openmrs/frontend_assembly">
+                  <fileset dir="${project.build.directory}/referenceapplication-frontend" />
+                  <mapper from="spa-assemble-config.json" to="reference-application-spa-assemble-config.json" type="regexp" />
+                </move>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+
+          <execution>
             <id>Copy filtered OpenMRS configuration</id>
             <phase>prepare-package</phase>
             <configuration>
@@ -326,6 +360,7 @@
               <goal>run</goal>
             </goals>
           </execution>
+
           <execution>
             <id>Copy filtered OpenMRS modules</id>
             <phase>prepare-package</phase>

--- a/maven-parent/pom.xml
+++ b/maven-parent/pom.xml
@@ -40,6 +40,12 @@
       <type>zip</type>
       <version>${ozone.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.ozonehis</groupId>
+      <artifactId>ozone-scripts</artifactId>
+      <type>zip</type>
+      <version>${ozone.version}</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -59,6 +65,18 @@
               <excludeTransitive>true</excludeTransitive>
               <outputDirectory>${project.build.directory}/ozone</outputDirectory>
               <includeArtifactIds>ozone</includeArtifactIds>
+            </configuration>
+          </execution>
+          <execution>
+            <id>Unpack Ozone Scripts</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>unpack-dependencies</goal>
+            </goals>
+            <configuration>
+              <excludeTransitive>true</excludeTransitive>
+              <outputDirectory>${project.build.directory}</outputDirectory>
+              <includeArtifactIds>ozone-scripts</includeArtifactIds>
             </configuration>
           </execution>
         </executions>
@@ -238,7 +256,7 @@
             <phase>process-resources</phase>
             <configuration>
               <scripts>
-                <script>file://${project.basedir}/scripts/openmrs/frontend_assembly/build-openmrs-frontend.groovy</script>
+                <script>file://${project.build.directory}/openmrs/frontend_assembly/build-openmrs-frontend.groovy</script>
               </scripts>
             </configuration>
           </execution>

--- a/ozone-distro-parent/pom.xml
+++ b/ozone-distro-parent/pom.xml
@@ -262,7 +262,7 @@
                       throw new RuntimeException("'openmrs assemble' step failed. See previous messages for details.")
                     }
 
-                    def buildProcess = "npx --legacy-peer-deps openmrs@${openmrsVersion} build --target ${project.build.directory}/${project.artifactId}-${project.version}/binaries/openmrs/frontend".execute()
+                    def buildProcess = "npx --legacy-peer-deps openmrs@${openmrsVersion} build --config-url "\$SPA_CONFIG_URLS" --default-locale "\$SPA_DEFAULT_LOCALE" --target ${project.build.directory}/${project.artifactId}-${project.version}/binaries/openmrs/frontend".execute()
                     buildProcess.consumeProcessOutput(System.out, System.err)
                     buildProcess.waitFor()
 

--- a/ozone-distro-parent/pom.xml
+++ b/ozone-distro-parent/pom.xml
@@ -230,73 +230,20 @@
       <plugin>
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
-        <version>3.0.2</version>
         <executions>
           <execution>
             <id>Rebuild OpenMRS Frontend if necessary</id>
             <goals>
               <goal>execute</goal>
             </goals>
-            <phase>process-classes</phase>
+            <phase>process-resources</phase>
             <configuration>
               <scripts>
-                <script><![CDATA[
-                  import java.nio.file.Paths
-
-                  log.info("Checking for frontend customizations in ${Paths.get("${project.build.directory}", "openmrs_frontend", "spa-assemble-config.json").toString()}")
-
-                  frontendCustomizationsFile = Paths.get("${project.build.directory}", "openmrs_frontend", "spa-assemble-config.json").toFile()
-                  if (frontendCustomizationsFile.exists()) {
-                    log.info("Found frontend customizations. Rebuilding frontend...")
-
-                    refAppConfigFile = Paths.get("${project.build.directory}", "openmrs_frontend", "reference-application-spa-assemble-config.json").toFile()
-                    slurper = new groovy.json.JsonSlurper()
-                    refAppConfig = slurper.parse(refAppConfigFile)
-                    openmrsVersion = refAppConfig["coreVersion"]
-
-                    def assembleProcess = "npx --legacy-peer-deps openmrs@${openmrsVersion} assemble --manifest --mode config --config ${refAppConfigFile.getAbsolutePath()} --config ${frontendCustomizationsFile.getAbsolutePath()} --target ${project.build.directory}/${project.artifactId}-${project.version}/binaries/openmrs/frontend".execute()
-                    assembleProcess.consumeProcessOutput(System.out, System.err)
-                    assembleProcess.waitFor()
-
-                    if (assembleProcess.exitValue() != 0) {
-                      throw new RuntimeException("'openmrs assemble' step failed. See previous messages for details.")
-                    }
-
-                    def buildProcess = "npx --legacy-peer-deps openmrs@${openmrsVersion} build --config-url "\$SPA_CONFIG_URLS" --default-locale "\$SPA_DEFAULT_LOCALE" --target ${project.build.directory}/${project.artifactId}-${project.version}/binaries/openmrs/frontend".execute()
-                    buildProcess.consumeProcessOutput(System.out, System.err)
-                    buildProcess.waitFor()
-
-                    if (buildProcess.exitValue() != 0) {
-                      throw new RuntimeException("'openmrs build' step failed. See previous messages for details.")
-                    }
-                  } else {
-                    log.info("No frontend customizations found.")
-                  }
-                ]]></script>
+                <script>file://${project.basedir}/scripts/openmrs/frontend_assembly/build-openmrs-frontend.groovy</script>
               </scripts>
             </configuration>
           </execution>
         </executions>
-        <dependencies>
-          <dependency>
-            <groupId>org.apache.groovy</groupId>
-            <artifactId>groovy</artifactId>
-            <version>4.0.18</version>
-            <scope>runtime</scope>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.groovy</groupId>
-            <artifactId>groovy-ant</artifactId>
-            <version>4.0.18</version>
-            <scope>runtime</scope>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.groovy</groupId>
-            <artifactId>groovy-json</artifactId>
-            <version>4.0.18</version>
-            <scope>runtime</scope>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/ozone-distro-parent/pom.xml
+++ b/ozone-distro-parent/pom.xml
@@ -11,7 +11,6 @@
     <relativePath>../ozone-parent</relativePath>
   </parent>
 
-  <groupId>com.ozonehis</groupId>
   <artifactId>ozone-distro-parent</artifactId>
   <name>Ozone Distribution Parent</name>
   <version>1.0.0-SNAPSHOT</version>
@@ -91,6 +90,49 @@
                     <exclude>distro/**/globalproperties/i18n.xml</exclude>
                     <exclude>distro/**/*demo.*</exclude>
                   </excludes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+
+          <execution>
+            <!-- Copy reference-application-spa-assemble-config.json to frontend working directory -->
+            <id>Copy reference-application-spa-assemble-config.json to local working directory</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/openmrs_frontend</outputDirectory>
+              <overwrite>true</overwrite>
+              <resources>
+                <resource>
+                  <directory>${project.build.directory}/ozone/distro/configs/openmrs/frontend_assembly</directory>
+                  <filtering>false</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+
+          <execution>
+            <!-- Copy local spa-assemble-config.json if any -->
+            <id>Copy spa-assemble-config.json</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>
+                ${project.build.directory}/openmrs_frontend
+              </outputDirectory>
+              <overwrite>true</overwrite>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/configs/openmrs/frontend_assembly</directory>
+                  <includes>
+                    <include>spa-assemble-config.json</include>
+                  </includes>
+                  <filtering>false</filtering>
                 </resource>
               </resources>
             </configuration>
@@ -183,6 +225,78 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <version>3.0.2</version>
+        <executions>
+          <execution>
+            <id>Rebuild OpenMRS Frontend if necessary</id>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <phase>process-classes</phase>
+            <configuration>
+              <scripts>
+                <script><![CDATA[
+                  import java.nio.file.Paths
+
+                  log.info("Checking for frontend customizations in ${Paths.get("${project.build.directory}", "openmrs_frontend", "spa-assemble-config.json").toString()}")
+
+                  frontendCustomizationsFile = Paths.get("${project.build.directory}", "openmrs_frontend", "spa-assemble-config.json").toFile()
+                  if (frontendCustomizationsFile.exists()) {
+                    log.info("Found frontend customizations. Rebuilding frontend...")
+
+                    refAppConfigFile = Paths.get("${project.build.directory}", "openmrs_frontend", "reference-application-spa-assemble-config.json").toFile()
+                    slurper = new groovy.json.JsonSlurper()
+                    refAppConfig = slurper.parse(refAppConfigFile)
+                    openmrsVersion = refAppConfig["coreVersion"]
+
+                    def assembleProcess = "npx --legacy-peer-deps openmrs@${openmrsVersion} assemble --manifest --mode config --config ${refAppConfigFile.getAbsolutePath()} --config ${frontendCustomizationsFile.getAbsolutePath()} --target ${project.build.directory}/${project.artifactId}-${project.version}/binaries/openmrs/frontend".execute()
+                    assembleProcess.consumeProcessOutput(System.out, System.err)
+                    assembleProcess.waitFor()
+
+                    if (assembleProcess.exitValue() != 0) {
+                      throw new RuntimeException("'openmrs assemble' step failed. See previous messages for details.")
+                    }
+
+                    def buildProcess = "npx --legacy-peer-deps openmrs@${openmrsVersion} build --target ${project.build.directory}/${project.artifactId}-${project.version}/binaries/openmrs/frontend".execute()
+                    buildProcess.consumeProcessOutput(System.out, System.err)
+                    buildProcess.waitFor()
+
+                    if (buildProcess.exitValue() != 0) {
+                      throw new RuntimeException("'openmrs build' step failed. See previous messages for details.")
+                    }
+                  } else {
+                    log.info("No frontend customizations found.")
+                  }
+                ]]></script>
+              </scripts>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>4.0.18</version>
+            <scope>runtime</scope>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy-ant</artifactId>
+            <version>4.0.18</version>
+            <scope>runtime</scope>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy-json</artifactId>
+            <version>4.0.18</version>
+            <scope>runtime</scope>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/ozone-parent/pom.xml
+++ b/ozone-parent/pom.xml
@@ -25,6 +25,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+    <maven.groovy.version>4.0.18</maven.groovy.version>
   </properties>
 
   <build>
@@ -58,6 +61,31 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>3.5.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.gmavenplus</groupId>
+          <artifactId>gmavenplus-plugin</artifactId>
+          <version>3.0.2</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.groovy</groupId>
+              <artifactId>groovy</artifactId>
+              <version>${maven.groovy.version}</version>
+              <scope>runtime</scope>
+            </dependency>
+            <dependency>
+              <groupId>org.apache.groovy</groupId>
+              <artifactId>groovy-ant</artifactId>
+              <version>${maven.groovy.version}</version>
+              <scope>runtime</scope>
+            </dependency>
+            <dependency>
+              <groupId>org.apache.groovy</groupId>
+              <artifactId>groovy-json</artifactId>
+              <version>${maven.groovy.version}</version>
+              <scope>runtime</scope>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.openmrs.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
   <modules>
     <module>maven-commons</module>
     <module>maven-parent</module>
+    <module>scripts</module>
     <module>distro</module>
   </modules>
 

--- a/scripts/assembly.xml
+++ b/scripts/assembly.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 http://maven.apache.org/xsd/assembly-2.2.0.xsd">
+  <id>zip-scripts-dir</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <outputDirectory>.</outputDirectory>
+      <directory>${project.build.directory}/${project.artifactId}-${project.version}</directory>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/scripts/openmrs/frontend_assembly/build-openmrs-frontend.groovy
+++ b/scripts/openmrs/frontend_assembly/build-openmrs-frontend.groovy
@@ -1,0 +1,47 @@
+import java.nio.file.Paths
+
+log.info("Checking for frontend customizations in ${Paths.get("${project.build.directory}", "openmrs_frontend", "spa-assemble-config.json").toString()}")
+
+def refAppConfigFile = Paths.get("${project.build.directory}", "openmrs_frontend", "reference-application-spa-assemble-config.json").toFile()
+def slurper = new groovy.json.JsonSlurper()
+def refAppConfig = slurper.parse(refAppConfigFile)
+def openmrsVersion = refAppConfig["coreVersion"] ?: "next"
+
+def assembleCommand = "npx --legacy-peer-deps openmrs@${openmrsVersion} assemble --manifest --mode config --target ${project.build.directory}/${project.artifactId}-${project.version}/binaries/openmrs/frontend --config ${refAppConfigFile.getAbsolutePath()}"
+log.info("Project: ${project.groupId}:${project.artifactId}")
+// by default, we build the frontend as part of Ozone and only rebuild if there are local customizations
+def shouldBuildFrontend = "${project.groupId}" == "com.ozonehis" && "${project.artifactId}" == "ozone-distro"
+
+if (!shouldBuildFrontend) {
+    frontendCustomizationsFile = Paths.get("${project.build.directory}", "openmrs_frontend", "spa-assemble-config.json").toFile()
+    if (frontendCustomizationsFile.exists()) {
+        log.info("Found frontend customizations. Rebuilding frontend...")
+
+        assembleCommand += "--config ${frontendCustomizationsFile.getAbsolutePath()}"
+        shouldBuildFrontend = true
+    }
+}
+
+if (shouldBuildFrontend) {
+    log.info("Running assemble command...")
+
+    def assembleProcess = assembleCommand.execute()
+    assembleProcess.consumeProcessOutput(System.out, System.err)
+    assembleProcess.waitFor()
+
+    if (assembleProcess.exitValue() != 0) {
+        throw new RuntimeException("'openmrs assemble' step failed. See previous messages for details.")
+    }
+
+    log.info("Running build command...")
+
+    def buildProcess = "npx --legacy-peer-deps openmrs@${openmrsVersion} build --config-url \$SPA_CONFIG_URLS --default-locale \$SPA_DEFAULT_LOCALE --target ${project.build.directory}/${project.artifactId}-${project.version}/binaries/openmrs/frontend".execute()
+    buildProcess.consumeProcessOutput(System.out, System.err)
+    buildProcess.waitFor()
+
+    if (buildProcess.exitValue() != 0) {
+        throw new RuntimeException("'openmrs build' step failed. See previous messages for details.")
+    }
+} else {
+    log.info("No need to re-build the frontend detected")
+}

--- a/scripts/pom.xml
+++ b/scripts/pom.xml
@@ -13,7 +13,7 @@
 
   <artifactId>ozone-scripts</artifactId>
   <name>Ozone Scripts</name>
-  <description>Shared scripts for Ozone</description>
+  <description>Shared utility scripts for Ozone</description>
   <packaging>pom</packaging>
 
   <organization>

--- a/scripts/pom.xml
+++ b/scripts/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.ozonehis</groupId>
+    <artifactId>maven-commons</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../maven-commons</relativePath>
+  </parent>
+
+  <artifactId>ozone-scripts</artifactId>
+  <name>Ozone Scripts</name>
+  <description>Shared scripts for Ozone</description>
+  <packaging>pom</packaging>
+
+  <organization>
+    <name>Ozone HIS</name>
+    <url>https://www.ozone-his.com</url>
+  </organization>
+  <developers>
+    <developer>
+      <name>Mekom Solutions</name>
+      <url>https://www.mekomsolutions.com</url>
+    </developer>
+  </developers>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- Copy scripts -->
+            <id>Copy local scripts</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>
+                ${project.build.directory}/${project.artifactId}-${project.version}</outputDirectory>
+              <overwrite>true</overwrite>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/../scripts</directory>
+                  <includes>
+                    <include>
+                      openmrs/frontend_assembly/build-openmrs-frontend.groovy
+                    </include>
+                    <include>
+                      go-to-scripts-dir.sh
+                    </include>
+                    <include>
+                      set-ozone-dir.sh
+                    </include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>Package scripts artifact</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <appendAssemblyId>false</appendAssemblyId>
+              <descriptors>
+                <descriptor>assembly.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
This is an attempt to fulfill OZ-462. I have not yet added docs, as there are some details I'm hoping to finalize.

**Assumptions:**

1. Machines running the distro have a recentish version Node / NPM (I think v16+) installed and available on the system PATH.
2. Ozone deployments do not actually need the customizations provided by spa-build-config.json.

**How this works:**

* Ozone now downloads the org.openmrs.distro:referenceapplication-frontend zip file and unpacks it in `$OZONE_DIR/configs/openmrs/frontend_assembly/reference-application-spa-assemble-config.json`
* An Ozone _distribution_ can provide a custom `spa-assemble-config.json` file in `$DISTRO_ROOT/configs/openmrs/frontend_assembly` that specifies their additions and removals.
* In an Ozone distribution, the `reference-application-spa-assemble-config.json` is copied to `${project.build.directory}/openmrs_frontend` and the `spa-assemble-config.json` file (if any) is copied to `${project.build.directory}/openmrs_frontend`.
* If a `spa-assemble-config.json` file is found, then the `assemble` (and, for now, at least, `build`) commands will be run. The outputs of this are published to `/distro/binaries/openmrs/frontend/`.

**Open questions:**

* Are these files in the right places or should they go somewhere else? (Little hard to know what to do with the assemble-configs; they aren't traditional config files in that they aren't part of the runtime, but they also aren't binaries for the same reason).
* Are the assumptions here ok?
* Do we need to always have some kind of output in `/distro/binaries/openmrs/frontend/`, e.g., so that this works with Docker?

(Apologies for adding yet more Groovy; I couldn't figure out how to do the necessary scripting in Ant)