### PR TITLE
Rename subprojects according to agreed standards

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -3,16 +3,14 @@
 
   <parent>
     <groupId>com.ozonehis</groupId>
-    <artifactId>ozone-parent</artifactId>
+    <artifactId>maven-commons</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>../ozone-parent</relativePath>
+    <relativePath>../maven-commons</relativePath>
   </parent>
 
-  <groupId>com.ozonehis</groupId>
   <artifactId>ozone-distro</artifactId>
   <name>Ozone Distribution</name>
-  <description></description>
-  <version>1.0.0-SNAPSHOT</version>
+  <description>The enterprise-grade health information system built with OpenMRS 3</description>
   <packaging>pom</packaging>
 
   <organization>
@@ -436,7 +434,6 @@
           <!-- copy over merged/packaged OpenMRS config for validation at the integration-test phase -->
           <plugin>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>1.7</version>
             <executions>
               <execution>
                 <id>Copy OpenMRS Initializer configs for validation</id>
@@ -458,7 +455,6 @@
           <plugin>
             <groupId>org.openmrs.maven.plugins</groupId>
             <artifactId>openmrs-packager-maven-plugin</artifactId>
-            <version>1.7.0</version>
             <executions>
               <execution>
                 <id>Validate OpenMRS Initializer configs</id>

--- a/maven-commons/pom.xml
+++ b/maven-commons/pom.xml
@@ -5,11 +5,11 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.ozonehis</groupId>
-  <artifactId>ozone-parent</artifactId>
-  <name>Ozone Parent</name>
+  <artifactId>maven-commons</artifactId>
   <version>1.0.0-SNAPSHOT</version>
+  <name>Ozone Maven Commons</name>
+  <description>Parent project for Ozone containing shared dependency versions and settings</description>
   <packaging>pom</packaging>
-  <description>Parent project for Ozone containing shared dependency versions</description>
 
   <organization>
     <name>Ozone HIS</name>

--- a/maven-commons/pom.xml
+++ b/maven-commons/pom.xml
@@ -25,6 +25,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
   </properties>
 
   <build>

--- a/maven-parent/pom.xml
+++ b/maven-parent/pom.xml
@@ -6,17 +6,15 @@
 
   <parent>
     <groupId>com.ozonehis</groupId>
-    <artifactId>ozone-parent</artifactId>
+    <artifactId>maven-commons</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>../ozone-parent</relativePath>
+    <relativePath>../maven-commons</relativePath>
   </parent>
 
-  <groupId>com.ozonehis</groupId>
-  <artifactId>ozone-distro-parent</artifactId>
-  <name>Ozone Distribution Parent</name>
-  <version>1.0.0-SNAPSHOT</version>
+  <artifactId>maven-parent</artifactId>
+  <name>Ozone Maven Parent</name>
+  <description>Parent project for Ozone implementation projects</description>
   <packaging>pom</packaging>
-  <description>Parent project for Ozone distributions</description>
 
   <organization>
     <name>Ozone HIS</name>
@@ -186,27 +184,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>validator</id>
-      <activation>
-        <property>
-          <name>env.CI</name>
-          <value>true</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-
-          <!-- hooking the OpenMRS config validation to the integration-test phase -->
-          <plugin>
-            <groupId>org.openmrs.maven.plugins</groupId>
-            <artifactId>openmrs-packager-maven-plugin</artifactId>
-          </plugin>
-
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,16 +2,15 @@
 
   <parent>
     <groupId>com.ozonehis</groupId>
-    <artifactId>ozone-parent</artifactId>
+    <artifactId>maven-commons</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>ozone-parent</relativePath>
+    <relativePath>maven-commons</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.ozonehis</groupId>
   <artifactId>ozone</artifactId>
   <name>Ozone</name>
-  <description></description>
+  <description>The enterprise-grade health information system built with OpenMRS 3</description>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
@@ -39,8 +38,8 @@
   </properties>
 
   <modules>
-    <module>ozone-parent</module>
-    <module>ozone-distro-parent</module>
+    <module>maven-commons</module>
+    <module>maven-parent</module>
     <module>distro</module>
   </modules>
 
@@ -153,7 +152,7 @@
         <artifactId>dependency-tracker-maven-plugin</artifactId>
         <executions>
           <execution>
-            <id>Complile dependency report</id>
+            <id>Compile dependency report</id>
             <phase>compile</phase>
             <goals>
               <goal>track</goal>
@@ -210,81 +209,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <repositories>
-    <repository>
-      <id>mks-nexus-public</id>
-      <url>https://nexus.mekomsolutions.net/repository/maven-public/</url>
-    </repository>
-    <repository>
-      <id>mks-nexus-public-snapshots</id>
-      <name>Mekom Solutions Nexus repo for snapshots</name>
-      <url>https://nexus.mekomsolutions.net/repository/maven-snapshots</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>openmrs-repo</id>
-      <name>OpenMRS Nexus Repository</name>
-      <url>https://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
-    </repository>
-    <repository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>openmrs-repo</id>
-      <name>OpenMRS Nexus Repository</name>
-      <url>https://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>
-    <pluginRepository>
-      <id>openmrs-snapshots</id>
-      <name>OpenMRS Public Repository</name>
-      <url>https://mavenrepo.openmrs.org/snapshots</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </pluginRepository>
-    <pluginRepository>
-      <id>mks-nexus-public</id>
-      <url>https://nexus.mekomsolutions.net/repository/maven-public/</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>mks-nexus-snapshots</id>
-      <url>https://nexus.mekomsolutions.net/repository/maven-snapshots/</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-
-
-  <distributionManagement>
-    <repository>
-      <name>Mekom Solutions Nexus repo for releases</name>
-      <id>mks-nexus-public-releases</id>
-      <url>https://nexus.mekomsolutions.net/repository/maven-releases</url>
-    </repository>
-    <snapshotRepository>
-      <name>Mekom Solutions Nexus repo for snapshots</name>
-      <id>mks-nexus-public-snapshots</id>
-      <url>https://nexus.mekomsolutions.net/repository/maven-snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
 </project>


### PR DESCRIPTION
This PR implements the agreed-on naming conventions for the stuff that's currently in the repo. I've also done some very small POM refactors to remove duplicate data (verified with `mvn help:effective-pom`).

| Folder | GroupId | ArtifactId | Purpose |
| ------ | -------- | --------- | -------- |
| maven-parent | com.ozonehis | maven-parent | Parent project for Ozone implementations |
| maven-commons | com.ozonehis | maven-commons | Shared Maven configurations for Ozone |

I've also renamed the thing I was calling a "distro" to "implementation", so, e.g., ozone-cambodia is an "Ozone implementation project"