### PR TITLE
INFRA-407: Update `check-deps` workflow to notify OCD3 only on dependency changes.

### DIFF
--- a/.github/workflows/check-deps.yml
+++ b/.github/workflows/check-deps.yml
@@ -10,13 +10,9 @@ jobs:
     uses: mekomsolutions/shared-github-workflow/.github/workflows/maven-check-deps-build-publish.yml@main
     with:
       java-version: "8"
+      notify-ocd3: true
+      ocd3-username: ${{ secrets.OCD3_USERNAME }}
+      ocd3-password: ${{ secrets.OCD3_PASSWORD }}
     secrets:
       NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-
-  notify-ocd3:
-    needs: check-deps
-    uses: mekomsolutions/shared-github-workflow/.github/workflows/ocd3-notify.yml@main
-    secrets:
-      OCD3_USERNAME: ${{ secrets.OCD3_USERNAME }}
-      OCD3_PASSWORD: ${{ secrets.OCD3_PASSWORD }}


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/browse/INFRA-407

- Update `check-deps` workflow to notify OCD3 only on dependency changes


This PR relates to https://github.com/mekomsolutions/shared-github-workflow/pull/30