### PR TITLE
OZ-462: Only clean output directory if needed

### DIFF
--- a/scripts/openmrs/frontend_assembly/build-openmrs-frontend.groovy
+++ b/scripts/openmrs/frontend_assembly/build-openmrs-frontend.groovy
@@ -11,10 +11,6 @@ def outputDirectory = "${project.groupId}" == "com.ozonehis" && "${project.artif
     "${project.build.directory}/${project.artifactId}-${project.version}/distro/binaries/openmrs/frontend"
 
 def outputDirectoryFile = new File(outputDirectory)
-if (outputDirectoryFile.exists()) {
-    outputDirectoryFile.eachFile(it -> it.delete())
-    outputDirectoryFile.eachDir(it -> { if (it.getName() != "ozone") { it.deleteDir() } })
-}
 
 def assembleCommand = "npx --legacy-peer-deps openmrs@${openmrsVersion} assemble --manifest --mode config --target ${outputDirectory} --config ${refAppConfigFile.getAbsolutePath()}"
 log.info("Project: ${project.groupId}:${project.artifactId}")
@@ -32,6 +28,12 @@ if (!shouldBuildFrontend) {
 }
 
 if (shouldBuildFrontend) {
+    log.info("Cleaning ${outputDirectory}...")
+    if (outputDirectoryFile.exists()) {
+        outputDirectoryFile.eachFile(it -> it.delete())
+        outputDirectoryFile.eachDir(it -> { if (it.getName() != "ozone") { it.deleteDir() } })
+    }
+
     log.info("Running assemble command...")
 
     def assembleProcess = assembleCommand.execute()


### PR DESCRIPTION
Move the step that cleans the output directory into a block that only executes when we are (re-)building the frontend, so that we don't accidentally clear it out by mistake.