### PR TITLE
OZ-450: Fix the 'install-latest.sh' script

### DIFF
--- a/scripts/install-latest.sh
+++ b/scripts/install-latest.sh
@@ -74,7 +74,7 @@ $mvn dependency:copy \
 -DoutputDirectory=./ \
 -DuseBaseVersion=true
 
-# Account for some inconsisitencies in some systems where Maven copies the files without a timestamp.
+# Account for some inconsistencies in some systems where Maven copies the files without a timestamp.
 # Only rename the file if it is time-stamped.
 if [ ! -f "ozone-${ozoneVersion}.zip" ]
 then

--- a/scripts/install-latest.sh
+++ b/scripts/install-latest.sh
@@ -74,7 +74,15 @@ $mvn dependency:copy \
 -DoutputDirectory=./ \
 -DuseBaseVersion=true
 
-mv ozone-1.0.0-*.zip ozone-${ozoneVersion}.zip  
+# Account for some inconsisitencies in some systems where Maven copies the files without a timestamp.
+# Only rename the file if it is time-stamped.
+if [ ! -f "ozone-${ozoneVersion}.zip" ]
+then
+    echo "$INFO Rename to 'ozone-${ozoneVersion}.zip'..."
+    mv ozone-1.0.0-*.zip ozone-${ozoneVersion}.zip
+fi
+
+echo "$INFO Unzipping..."
 unzip ozone-${ozoneVersion}.zip -d ${ozoneInstallFolder}
 rm ozone-${ozoneVersion}.zip
 pushd ozone/run/docker/scripts/


### PR DESCRIPTION
As per reported on Slack by @kdaud : https://mekomsolutions.slack.com/archives/G421UNF5L/p1710755159424749

PR is making sure that the file is renamed only when the file is timestamped, which is not consistently the case.