### PR TITLE
OZ-464: Uncompress init sql dump and add missing item data.

### DIFF
--- a/distro/configs/erpnext/initializer_config/item_price/insert_item_price.csv
+++ b/distro/configs/erpnext/initializer_config/item_price/insert_item_price.csv
@@ -116,7 +116,6 @@ e79df49a-71a6-4169-952c-0225048cb482,Standard Selling,0.5,USD,Tablet
 8d883d65-9473-46ff-8b14-0ebe1f9a86da,Standard Selling,1,USD,Vial
 a20b435b-a8f8-4727-b2be-bcc5d2befd33,Standard Selling,0.5,USD,Vial
 91450143-ca6e-46fe-9fff-274be47521db,Standard Selling,1,USD,Tablet
-b9934447-70bb-4ef3-a65d-ff7cffe39025,Standard Selling,0.5,USD,Tablet
 b257beaf-a967-4822-8f78-9f87be045959,Standard Selling,1,USD,Tablet
 ca382f91-17b3-4b54-973e-8ccbdd89b8e1,Standard Selling,0.9,USD,Tablet
 9c38ea14-0972-46a9-9dac-76cafbb44971,Standard Selling,0.94,USD,Tablet
@@ -330,7 +329,6 @@ c933dc30-36f6-471f-bca6-53d8a682dce1,Standard Selling,1,USD,Tablet
 2b6dca2c-1499-4724-8648-42d996a57c6d,Standard Selling,0.5,USD,Vial
 25dc03a6-b2ca-46d5-8121-43ab025b3e9c,Standard Selling,1,USD,Tube
 057862ef-9fe0-40c8-8955-3149b25c4a70,Standard Selling,0.5,USD,Tablet
-31fe8ffe-3a78-435c-81b2-153fa11deb32,Standard Selling,1,USD,Vial
 5650eb5e-97e5-45ed-8b61-46920d3bbc43,Standard Selling,0.9,USD,Vial
 17e9b385-de8b-4d60-a7de-c37cbe2a3d1c,Standard Selling,0.94,USD,Vial
 e5574e71-17ea-434f-8649-eba766be4087,Standard Selling,0.99,USD,Tube

--- a/distro/configs/erpnext/initializer_config/items/insert_item.csv
+++ b/distro/configs/erpnext/initializer_config/items/insert_item.csv
@@ -36,6 +36,16 @@ ID,Default Unit of Measure,Item Code,Item Group,Item Name
 785AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,Unit,Alkaline phosphatase,Laboratory,Alkaline phosphatase
 159362AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,Unit,Fecal occult blood test,Laboratory,Fecal occult blood test
 1019AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,Unit,Complete blood count,Laboratory,Complete blood count
+679AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,Unit,Red blood cells,Laboratory,Red blood cells
+1336AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,Unit,Neutrophils (%) - microscopic exam,Laboratory,Neutrophils (%) - microscopic exam
+163692AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,Unit,Epithelial casts presence in urine sediment by light microscopy test,Laboratory,Epithelial casts presence in urine sediment by light microscopy test
+1018AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,Unit,Mean corpuscular hemoglobin,Laboratory,Mean corpuscular hemoglobin
+1017AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,Unit,Mean cell hemoglobin concentration,Laboratory,Mean cell hemoglobin concentration
+161431AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,Unit,Sickling test only,Laboratory,Sickling test only
+161488AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,Unit,Renal function panel,Laboratory,Renal function panel
+953AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,Unit,Liver function tests,Laboratory,Liver function tests
+161451AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,Unit,Stool test,Laboratory,Stool test
+163697AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,Unit,Urine microscopy panel,Laboratory,Urine microscopy panel
 3543c654-0834-4c90-982c-5e277005c15d,Tablet,Griséofulvine Co 500mg,Drugs,Griséofulvine Co 500mg
 0bd1bf31-b974-421f-854d-b9d463630a2b,Tablet,Tylenol 325mg,Drugs,Tylenol 325mg
 3af6ca73-f2ee-43ff-8464-fa00bf525e9b,Tablet,Advil 200mg,Drugs,Advil 200mg


### PR DESCRIPTION
This PR does:
- Uncompress init SQL dump file to.sql to fix permission issue.
- Add Item missing data.
- Configure ERPNext Quotation Item with the custom field "ExternalID" which maps to ServiceRequest/MedicationRequest UUID.