### PR TITLE
OZ-196: Remove default exclusions from Maven parent so new Ozone distro is usable

### DIFF
--- a/maven-parent/pom.xml
+++ b/maven-parent/pom.xml
@@ -104,6 +104,7 @@
         <executions>
          <execution>
             <!-- Exclude files from Ozone -->
+            <!-- We exclude nothing here, but distros should override this with any exclusions they need -->
             <id>Exclude unneeded Ozone files</id>
             <phase>process-resources</phase>
             <goals>
@@ -116,13 +117,6 @@
               <resources>
                 <resource>
                   <directory>${project.build.directory}/ozone</directory>
-                  <excludes>
-                    <exclude>distro/**/addresshierarchy/*.*</exclude>
-                    <exclude>distro/**/ampathforms/*.json</exclude>
-                    <exclude>distro/**/ampathformstranslations/*.json</exclude>
-                    <exclude>distro/**/globalproperties/i18n.xml</exclude>
-                    <exclude>distro/**/*demo.*</exclude>
-                  </excludes>
                 </resource>
               </resources>
             </configuration>


### PR DESCRIPTION
In order to make setting up a new distro easier, we remove the default exclusions from the maven-parent. Most concrete distributions will end up with their own custom exclusions anyways, so this is not just redundant, but makes the experience of setting up Ozone more difficult.