### PR TITLE
OZ-632: install-stable.sh to temporarily create a pom file

### DIFF
--- a/scripts/install-stable.sh
+++ b/scripts/install-stable.sh
@@ -130,7 +130,7 @@ cat >_temp_install-latest-ozone-pom.xml <<EOF
 EOF
 
 echo "$INFO Download and extract Ozone $ozoneVersion..."
-$mvn clean package
+$mvn clean package -f _temp_install-latest-ozone-pom.xml
 rm _temp_install-latest-ozone-pom.xml
 
 # Move to the scripts/ folder


### PR DESCRIPTION
https://mekomsolutions.atlassian.net/browse/OZ-632

This PR changes the install-stable.sh script to deprecate the use of CLI command for `dependency:get` and `dependency:copy` which misbehaves on releases.
See [Slack conversation](https://mekomsolutions.slack.com/archives/G421UNF5L/p1719338028599899).

This creates a temporary pom file to set an Ozone dependency and fetch it + export in a local ozone/ folder.

To test the PR:

```
curl -s https://raw.githubusercontent.com/ozone-his/ozone/OZ-632/scripts/install-stable.sh | bash /dev/stdin
```