### PR TITLE
OZ-529: Add `generate-import-script.groovy` to `ozone-scripts` and adjust phase for script execution

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -502,7 +502,7 @@
             <goals>
               <goal>execute</goal>
             </goals>
-            <phase>process-resources</phase>
+            <phase>prepare-package</phase>
             <configuration>
               <scripts>
                 <script>

--- a/scripts/erpnext/data_import/generate-import-script.groovy
+++ b/scripts/erpnext/data_import/generate-import-script.groovy
@@ -24,7 +24,7 @@ static def getCSVFilesRecursively(File dir) {
 }
 
 // Path to the directory containing the CSV files
-def csvDirPath = Paths.get("${project.basedir}/configs/erpnext/initializer_config")
+def csvDirPath = Paths.get("${project.build.directory}/${project.artifactId}-${project.version}/configs/erpnext/initializer_config")
 
 // Get all CSV files in the directory
 def csvFiles = getCSVFilesRecursively(csvDirPath.toFile())

--- a/scripts/pom.xml
+++ b/scripts/pom.xml
@@ -52,6 +52,9 @@
                       openmrs/frontend_assembly/build-openmrs-frontend.groovy
                     </include>
                     <include>
+                      erpnext/data_import/generate-import-script.groovy
+                    </include>
+                    <include>
                       go-to-scripts-dir.sh
                     </include>
                     <include>


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/jira/software/c/projects/OZ/issues/OZ-529

This PR adds `generate-import-script.groovy` to `ozone-scripts` package and modifies the Maven build phase to `prepare-package`. The purpose of these changes is to enable the Groovy script to dynamically read configuration files from the target directory during the build process