### PR TITLE
OZ-627: Update `install-stable.sh` to create new installation folder with numeric suffix if already exists

### DIFF
--- a/scripts/install-stable.sh
+++ b/scripts/install-stable.sh
@@ -28,19 +28,17 @@ echo "$INFO Ozone version: $ozoneVersion"
 
 ozoneInstallFolder="$PWD/ozone"
 # Check if ozone/ folder is already present
-if [ -d "${ozoneInstallFolder}" ]
-then
+if [ -d "${ozoneInstallFolder}" ]; then
     echo "$WARN Ozone installation directory (${ozoneInstallFolder}/) already exists."
-    while true; do
-    read -p "Do you want to overwrite? [y/n]" choice
-    case "$choice" in 
-        y|Y ) rm -r ${ozoneInstallFolder}/;
-            break;;
-        n|N )  echo "$INFO Aborting.";
-            exit 0;;
-        * ) echo "Please enter y, Y, n or N.";;
-    esac
+    suffix=1
+    while [ -d "${ozoneInstallFolder}_${suffix}" ]; do
+        suffix=$((suffix + 1))
     done
+    newOzoneInstallFolder="${ozoneInstallFolder}_${suffix}"
+    echo "$INFO Creating new installation directory (${newOzoneInstallFolder}/)."
+    ozoneInstallFolder="$newOzoneInstallFolder"
+    mkdir -p "$ozoneInstallFolder"
+    echo "$INFO If you want to overwrite the existing ozone/ folder, please delete it first."
 fi
 
 # Download Maven and install locally
@@ -110,7 +108,7 @@ cat >_temp_install-latest-ozone-pom.xml <<EOF
                         <configuration>
                             <excludeTransitive>true</excludeTransitive>
                             <excludeTypes>pom</excludeTypes>
-                            <outputDirectory>ozone</outputDirectory>
+                            <outputDirectory>$ozoneInstallFolder</outputDirectory>
                             <includeArtifactIds>ozone</includeArtifactIds>
                         </configuration>
                     </execution>

--- a/scripts/install-stable.sh
+++ b/scripts/install-stable.sh
@@ -26,7 +26,8 @@ ozoneVersion=${1:-1.0.0-alpha.11}
 
 echo "$INFO Ozone version: $ozoneVersion"
 
-ozoneInstallFolder="$PWD/ozone"
+ozoneFolderName="ozone"
+ozoneInstallFolder="$PWD/$ozoneFolderName"
 # Check if ozone/ folder is already present
 if [ -d "${ozoneInstallFolder}" ]; then
     echo "$WARN Ozone installation directory (${ozoneInstallFolder}/) already exists."
@@ -38,7 +39,7 @@ if [ -d "${ozoneInstallFolder}" ]; then
     echo "$INFO Creating new installation directory (${newOzoneInstallFolder}/)."
     ozoneInstallFolder="$newOzoneInstallFolder"
     mkdir -p "$ozoneInstallFolder"
-    echo "$INFO If you want to overwrite the existing ozone/ folder, please delete it first."
+    echo "$INFO If you want to overwrite the existing '${ozoneFolderName}/' folder, please delete it first."
 fi
 
 # Download Maven and install locally


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/browse/OZ-627

This PR adds the change, if the `ozone/` folder exists, the script iterates to find the next available folder name with a numeric suffix (e.g., `ozone_1`, `ozone_2`). Also, adds informational message to guide the user on how to overwrite the existing `ozone/` folder if desired.