### PR TITLE
OZ-672: Update maven wrapper distribution to `v3.9.9`

### DIFF
--- a/maven-archetype/src/test/resources/projects/it-basic/reference/scripts/.mvn/wrapper/maven-wrapper.properties
+++ b/maven-archetype/src/test/resources/projects/it-basic/reference/scripts/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.8/apache-maven-3.9.8-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar


### PR DESCRIPTION

This PR updates maven wrapper distribution to latest released(`v3.9.9`)