### PR TITLE
OZ-627: Add step to generate and copy Ozone info file

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -362,8 +362,8 @@
           </execution>
 
           <execution>
-            <!-- Copy the ozone-info.json file to final Distro -->
-            <id>Copy Ozone Info to Final Distro</id>
+            <!-- Copy ozone-info.json file to the final package -->
+            <id>Copy Ozone Info to the final package</id>
             <phase>prepare-package</phase>
             <goals>
               <goal>copy-resources</goal>
@@ -517,7 +517,7 @@
           </execution>
 
           <execution>
-            <id>Generate Ozone Info JSON</id>
+            <id>Generate Ozone Info JSON file</id>
             <phase>process-resources</phase>
             <goals>
               <goal>execute</goal>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -361,6 +361,27 @@
             </configuration>
           </execution>
 
+          <execution>
+            <!-- Copy the ozone-info.json file to final Distro -->
+            <id>Copy Ozone Info to Final Distro</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/${project.artifactId}-${project.version}</outputDirectory>
+              <overwrite>true</overwrite>
+              <resources>
+                <resource>
+                  <directory>${project.build.directory}</directory>
+                  <includes>
+                    <include>ozone-info.json</include>
+                  </includes>
+                  <filtering>false</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 
@@ -491,6 +512,20 @@
               <scripts>
                 <script>
                   file://${project.basedir}/../scripts/openmrs/frontend_assembly/build-openmrs-frontend.groovy</script>
+              </scripts>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>Generate Ozone Info JSON</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <scripts>
+                <script>
+                  file://${project.basedir}/../scripts/generate-ozone-info.groovy</script>
               </scripts>
             </configuration>
           </execution>

--- a/maven-parent/pom.xml
+++ b/maven-parent/pom.xml
@@ -291,28 +291,6 @@
               </resources>
             </configuration>
           </execution>
-
-          <execution>
-            <!-- Copy Ozone Info to Final Distro -->
-            <id>Copy Ozone Info to Final Distro</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/${project.artifactId}-${project.version}/distro</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${project.build.directory}</directory>
-                  <includes>
-                    <include>ozone-info.txt</include>
-                  </includes>
-                  <filtering>false</filtering>
-                </resource>
-              </resources>
-              <overwrite>true</overwrite>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
 
@@ -351,17 +329,22 @@
           </execution>
 
           <execution>
-            <!-- Generate Ozone Distro Info -->
-            <id>Generate Ozone Distro Info</id>
-            <phase>generate-resources</phase>
+            <id>Update Ozone Info</id>
+            <phase>process-resources</phase>
             <goals>
               <goal>run</goal>
             </goals>
             <configuration>
               <target>
-                <echo file="${project.build.directory}/ozone-info.txt">
-                  ozone.name=${project.artifactId}
-                </echo>
+                <taskdef name="groovy" classname="org.codehaus.groovy.ant.Groovy" classpathref="maven.plugin.classpath"/>
+                <groovy>
+                  def ozoneInfoFile = new File("${project.build.directory}/${project.artifactId}-${project.version}/distro/ozone-info.json")
+                  def ozoneInfo = new groovy.json.JsonSlurper().parse(ozoneInfoFile)
+                  ozoneInfo.name = "${project.artifactId}"
+                  ozoneInfo.version = "${project.version}"
+                  ozoneInfo.description = "${project.description}"
+                  ozoneInfoFile.text = groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(ozoneInfo))
+                </groovy>
               </target>
             </configuration>
           </execution>
@@ -377,6 +360,16 @@
                 <artifactId>ant</artifactId>
               </exclusion>
             </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy-ant</artifactId>
+            <version>${maven.groovy.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy-json</artifactId>
+            <version>${maven.groovy.version}</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/maven-parent/pom.xml
+++ b/maven-parent/pom.xml
@@ -291,6 +291,28 @@
               </resources>
             </configuration>
           </execution>
+
+          <execution>
+            <!-- Copy Ozone Info to Final Distro -->
+            <id>Copy Ozone Info to Final Distro</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/${project.artifactId}-${project.version}/distro</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.build.directory}</directory>
+                  <includes>
+                    <include>ozone-info.txt</include>
+                  </includes>
+                  <filtering>false</filtering>
+                </resource>
+              </resources>
+              <overwrite>true</overwrite>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 
@@ -324,6 +346,22 @@
                     </delete>
                   </then>
                 </if>
+              </target>
+            </configuration>
+          </execution>
+
+          <execution>
+            <!-- Generate Ozone Distro Info -->
+            <id>Generate Ozone Distro Info</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <echo file="${project.build.directory}/ozone-info.txt">
+                  ozone.name=${project.artifactId}
+                </echo>
               </target>
             </configuration>
           </execution>

--- a/scripts/generate-ozone-info.groovy
+++ b/scripts/generate-ozone-info.groovy
@@ -1,0 +1,9 @@
+import groovy.json.JsonOutput
+
+def json = [
+        name: 'ozone',
+        version: project.version,
+        description: project.description
+]
+
+new File(project.build.directory, 'ozone-info.json').text = JsonOutput.prettyPrint(JsonOutput.toJson(json))

--- a/scripts/pom.xml
+++ b/scripts/pom.xml
@@ -58,6 +58,9 @@
                       erpnext/data_import/generate-import-script.groovy
                     </include>
                     <include>
+                      generate-ozone-info.groovy
+                    </include>
+                    <include>
                       go-to-scripts-dir.sh
                     </include>
                     <include>


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/jira/software/c/projects/OZ/issues/OZ-627

- Added a new execution step in the `maven-antrun-plugin` to generate the `ozone-info.txt` file on the fly and another one in the `maven-resources-plugin` to copy the generated `ozone-info.txt` file to the final distro zip.