### PR TITLE
OZ-624: Increase check deps timeout to 20 minutes

### DIFF
--- a/.github/workflows/check-deps.yml
+++ b/.github/workflows/check-deps.yml
@@ -11,6 +11,7 @@ jobs:
     with:
       java-version: "8"
       notify-ocd3: true
+      check-deps-timeout-minutes: 20
     secrets:
       NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}


### PR DESCRIPTION
Associating to the Issue: https://mekomsolutions.atlassian.net/jira/software/c/projects/OZ/issues/OZ-624 as it highlights the issue where the `check-deps` workflow time outs when there's a change. 

This PR Updates the `check-deps-timeout-minutes` parameter in `check-deps` GA workflow to 20 minutes. This change ensures that the dependency check process has sufficient time to complete, reducing the likelihood of timeout errors.