### PR TITLE
Override `maven-archetype-plugin` to add `groovy-json` dependency

### DIFF
--- a/maven-archetype/pom.xml
+++ b/maven-archetype/pom.xml
@@ -39,6 +39,25 @@
           <ignoreEOLStyle>true</ignoreEOLStyle>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-archetype-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy-json</artifactId>
+            <version>${maven.groovy.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
- Override `maven-archetype-plugin` to add `groovy-json` dependency