### PR TITLE
OZ-708: Add InventoryItem and ChargeItemDefinition privileges and configure `fhirproxy` module

### DIFF
--- a/distro/configs/openmrs/initializer_config/globalproperties/fhirproxy-privileges-props.xml
+++ b/distro/configs/openmrs/initializer_config/globalproperties/fhirproxy-privileges-props.xml
@@ -1,0 +1,14 @@
+<config>
+    <globalProperties>
+        <globalProperty>
+            <property>fhirproxy.charge.item.definition.privileges</property>
+            <value>Get ChargeItemDefinition</value>
+            <description>Privileges required to access ChargeItemDefinition resources</description>
+        </globalProperty>
+        <globalProperty>
+            <property>fhirproxy.inventory.item.privileges</property>
+            <value>Get InventoryItem</value>
+            <description>Privileges required to access InventoryItem resources</description>
+        </globalProperty>
+    </globalProperties>
+</config>

--- a/distro/configs/openmrs/initializer_config/privileges/privileges_stock-and-price.csv
+++ b/distro/configs/openmrs/initializer_config/privileges/privileges_stock-and-price.csv
@@ -1,3 +1,3 @@
 Uuid,Privilege name,Description,_order:1000
-8578353f-0dea-4e12-803e-00d75627fab7,Get InventoryItem,Get InventoryItem,
-9b8cfdec-1788-4cb5-9a2e-c14852650655,Get ChargeItemDefinition,Get ChargeItemDefinition,
+8578353f-0dea-4e12-803e-00d75627fab7,Get InventoryItem,Able to get InventoryItems,
+9b8cfdec-1788-4cb5-9a2e-c14852650655,Get ChargeItemDefinition,Able to get ChargeItemDefinitions,

--- a/distro/configs/openmrs/initializer_config/privileges/privileges_stock-and-price.csv
+++ b/distro/configs/openmrs/initializer_config/privileges/privileges_stock-and-price.csv
@@ -1,0 +1,3 @@
+Uuid,Privilege name,Description,_order:1000
+8578353f-0dea-4e12-803e-00d75627fab7,Get InventoryItem,Get InventoryItem,
+9b8cfdec-1788-4cb5-9a2e-c14852650655,Get ChargeItemDefinition,Get ChargeItemDefinition,


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/jira/software/c/projects/OZ/issues/OZ-708

This PR adds InventoryItem and ChargeItemDefinition privileges and configures `fhirproxy` module with the newly created privileges.