### PR TITLE
OZ-698: Bump `openmrs-packager-maven-plugin` to `v1.9.0-SNAPSHOT`

### DIFF
--- a/maven-commons/pom.xml
+++ b/maven-commons/pom.xml
@@ -90,7 +90,7 @@
         <plugin>
           <groupId>org.openmrs.maven.plugins</groupId>
           <artifactId>openmrs-packager-maven-plugin</artifactId>
-          <version>1.7.0</version>
+          <version>1.9.0-SNAPSHOT</version>
         </plugin>
         <plugin>
           <groupId>net.mekomsolutions.maven.plugin</groupId>


### PR DESCRIPTION
- Upgrades openmrs-packager-maven-plugin to `v1.9.0-SNAPSHOT`.