### PR TITLE
OZ-573: Add `bundled-docker` start helper scripts

### DIFF
--- a/maven-parent/pom.xml
+++ b/maven-parent/pom.xml
@@ -519,6 +519,30 @@
                   </resources>
                 </configuration>
               </execution>
+              <execution>
+                <!-- Copy start-ozone-bundled.sh, start-ozone-bundled-sso.sh to scripts folder-->
+                <id>Copy Ozone bundled helper scripts</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>
+                    ${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts
+                  </outputDirectory>
+                  <overwrite>true</overwrite>
+                  <resources>
+                    <resource>
+                      <directory>${project.build.directory}/bundled-docker-build-tmp/bundled-docker/scripts</directory>
+                      <filtering>true</filtering>
+                      <includes>
+                        <include>start-bundled.sh</include>
+                        <include>start-bundled-sso.sh</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
             </executions>
           </plugin>
           <plugin>


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/browse/OZ-573

This PR copies `bundled-docker` start helper scripts to `scripts/` in the final package.