### PR TITLE
OZ-753: Add `localhost:8088` to Superset client redirect URIs

### DIFF
--- a/distro/configs/keycloak/realms/ozone-realm.json
+++ b/distro/configs/keycloak/realms/ozone-realm.json
@@ -1262,7 +1262,8 @@
       "clientAuthenticatorType": "client-secret",
       "secret": "${SUPERSET_CLIENT_SECRET}",
       "redirectUris": [
-        "${SUPERSET_PUBLIC_URL}/*"
+        "${SUPERSET_PUBLIC_URL}/*",
+        "http://localhost:8088/*"
       ],
       "webOrigins": [],
       "notBefore": 0,


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/browse/OZ-753

- This PR adds http://localhost:8088 URL to valid redirect URIs for Superset client in Keycloak