### PR TITLE
HSC-380: Fix Odoo report printing timeout issue when server does not have Internet access

### DIFF
--- a/distro/configs/odoo/initializer_config/setting/ir.config.parameter.xml
+++ b/distro/configs/odoo/initializer_config/setting/ir.config.parameter.xml
@@ -1,0 +1,6 @@
+<data noupdate="1">
+   <record id="report_url" model="ir.config_parameter">
+      <field name="key">report.url</field>
+      <field name="value">http://127.0.0.1:8069</field>
+   </record>
+</data>


### PR DESCRIPTION
This is a follow-up to an issue we manually fixed for HSC where PDFs took too long to generate When the server could not access the Internet