### PR TITLE
OZ-402: Add build step to merge `.env` files in `maven-parent`

### DIFF
--- a/maven-parent/pom.xml
+++ b/maven-parent/pom.xml
@@ -276,7 +276,7 @@
           <execution>
             <!-- Copy OpenMRS modules -->
             <id>Copy OpenMRS modules</id>
-            <phase>package</phase>
+            <phase>prepare-package</phase>
             <goals>
               <goal>copy-resources</goal>
             </goals>

--- a/maven-parent/pom.xml
+++ b/maven-parent/pom.xml
@@ -243,7 +243,7 @@
                   <includes>
                     <include>docker-compose-files.txt</include>
                     <include>start-ozone.sh</include>
-                    <include>distro.env</include>
+                    <include>*.env</include>
                   </includes>
                   <filtering>true</filtering>
                 </resource>
@@ -311,10 +311,8 @@
                 <merge>
                   <target>
                     ${project.build.directory}/${project.artifactId}-${project.version}/run/docker/concatenated.env</target>
-                  <sources>
-                    <source>${project.build.directory}/${project.artifactId}-${project.version}/run/docker/.env</source>
-                    <source>${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/distro.env</source>
-                  </sources>
+                  <searchDir>${project.build.directory}/${project.artifactId}-${project.version}/run/docker</searchDir>
+                  <pattern>.*\.env</pattern>
                   <override>true</override>
                 </merge>
               </merges>

--- a/maven-parent/pom.xml
+++ b/maven-parent/pom.xml
@@ -243,6 +243,7 @@
                   <includes>
                     <include>docker-compose-files.txt</include>
                     <include>start-ozone.sh</include>
+                    <include>distro.env</include>
                   </includes>
                   <filtering>true</filtering>
                 </resource>
@@ -275,7 +276,7 @@
           <execution>
             <!-- Copy OpenMRS modules -->
             <id>Copy OpenMRS modules</id>
-            <phase>prepare-package</phase>
+            <phase>package</phase>
             <goals>
               <goal>copy-resources</goal>
             </goals>
@@ -288,6 +289,35 @@
                   <directory>${project.build.directory}/openmrs_modules</directory>
                 </resource>
               </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Merge Ozone .env and distro.env files -->
+      <plugin>
+        <groupId>com.bekioui.maven.plugin</groupId>
+        <artifactId>merge-maven-plugin</artifactId>
+        <version>1.2.0</version>
+        <executions>
+          <execution>
+            <id>Merge env files</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>merge</goal>
+            </goals>
+            <configuration>
+              <merges>
+                <merge>
+                  <target>
+                    ${project.build.directory}/${project.artifactId}-${project.version}/run/docker/concatenated.env</target>
+                  <sources>
+                    <source>${project.build.directory}/${project.artifactId}-${project.version}/run/docker/.env</source>
+                    <source>${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/distro.env</source>
+                  </sources>
+                  <override>true</override>
+                </merge>
+              </merges>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
JIRA: https://mekomsolutions.atlassian.net/browse/HSC-402
With this PR the plugin will look for all the `*.env` files in `scripts` directory and merge them according to names
Example:
Haiti  (Parent Distro) env file should be named `ozoneb.env`
HSC (Child Distro) env file should be named `ozonea.env`
So the order of merging will be `.env` then `ozoneb.env` then `ozonea.env`
Meaning the merge happens in reverse order.
