### PR TITLE
OZ-874: Use fhir2 module `v2.3.0`

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -35,6 +35,7 @@
     <commonreportsVersion>1.5.0-SNAPSHOT</commonreportsVersion>
     <oauth2loginVersion>1.6.0-SNAPSHOT</oauth2loginVersion>
     <fhirproxyVersion>1.1.0-SNAPSHOT</fhirproxyVersion>
+    <fhir2Version>2.3.0</fhir2Version>
     <patientsummaryVersion>2.2.0</patientsummaryVersion>
 
     <!-- EIP Routes artifact versions -->
@@ -107,6 +108,12 @@
       <groupId>org.openmrs.module</groupId>
       <artifactId>oauth2login-omod</artifactId>
       <version>${oauth2loginVersion}</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.openmrs.module</groupId>
+      <artifactId>fhir2-omod</artifactId>
+      <version>${fhir2Version}</version>
       <type>jar</type>
     </dependency>
 
@@ -546,6 +553,7 @@
                   <fileset
                     dir="${project.build.directory}/distro-emr-configuration/sdk-distro/web/modules">
                     <exclude name="authentication-*.omod"/>
+                    <exclude name="fhir2-2.2.0.omod"/>
                   </fileset>
                 </copy>
               </target>


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/browse/OZ-874

This PR bumps OpenMRS fhir2 module to `v2.3.0`