### PR TITLE
OZ-741: Add `dcm4che` repository to `maven-commons`

### DIFF
--- a/maven-commons/pom.xml
+++ b/maven-commons/pom.xml
@@ -132,6 +132,10 @@
       <name>bahmni-artifactory-release</name>
       <url>https://repo.mybahmni.org/artifactory/release</url>
     </repository>
+    <repository>
+      <id>dcm4che</id>
+      <url>https://maven.dcm4che.org/</url>
+    </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/browse/OZ-741

This PR adds `dcm4che` repository to `maven-commons`