### PR TITLE
OZ-841: 'install-stable.sh' to point to 1.0.0-alpha.13

### DIFF
--- a/scripts/install-stable.sh
+++ b/scripts/install-stable.sh
@@ -22,7 +22,7 @@ echo ""
 
 
 # TODO: Upon release, replace this with the latest stable version
-ozoneVersion=${1:-1.0.0-SNAPSHOT}
+ozoneVersion=${1:-1.0.0-alpha.13}
 
 echo "$INFO Ozone version: $ozoneVersion"
 


### PR DESCRIPTION
As per Slack conversation: https://openmrs.slack.com/archives/C02PYQD5D0A/p1744730755964619

> The script should be pointing to the latest stable

