### PR TITLE
OZ-935: Update OAuth2 login redirect URI to `/spa/login`

### DIFF
--- a/distro/configs/openmrs/initializer_config/globalproperties/oauth2-login-props.xml
+++ b/distro/configs/openmrs/initializer_config/globalproperties/oauth2-login-props.xml
@@ -2,7 +2,7 @@
     <globalProperties>
         <globalProperty>
             <property>oauth2login.redirectUriAfterLogin</property>
-            <value>/spa/home</value>
+            <value>/spa/login/location</value>
         </globalProperty>
     </globalProperties>
 </config>

--- a/distro/configs/openmrs/initializer_config/globalproperties/oauth2-login-props.xml
+++ b/distro/configs/openmrs/initializer_config/globalproperties/oauth2-login-props.xml
@@ -2,7 +2,7 @@
     <globalProperties>
         <globalProperty>
             <property>oauth2login.redirectUriAfterLogin</property>
-            <value>/spa/login/location</value>
+            <value>/spa/login</value>
         </globalProperty>
     </globalProperties>
 </config>


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/browse/OZ-935

This PR updates the OAuth2 login redirect URI to `/spa/login/location`.

Previously, after a successful login, users were first redirected to the home page and then to the location picker. As a result, home page esm apps attempted to load before the user's location is set, causing network requests to fail due to the location being undefined.

