### PR TITLE
Remove MIT license as Odoo does not support it

### DIFF
--- a/distro/binaries/odoo/addons/ozone_settings/__manifest__.py
+++ b/distro/binaries/odoo/addons/ozone_settings/__manifest__.py
@@ -12,7 +12,6 @@
 
     'author': 'enyachoke',
     'website': 'https://mekomsolutions.com',
-    'license': 'MIT',
     'category': 'Technical Settings',
     'version': '17.0.0.0.0',
 


### PR DESCRIPTION
Remove the MIT license from the Manifest as it is not supported by Odoo https://www.odoo.com/documentation/18.0/developer/reference/backend/module.html