### PR TITLE
OZ-962: Odoo custom fields `x_customer_weight` and `x_customer_dob` not created following Odoo 17 upgrade

### DIFF
--- a/distro/configs/odoo/initializer_config/models/ir.model.1000.csv
+++ b/distro/configs/odoo/initializer_config/models/ir.model.1000.csv
@@ -1,2 +1,0 @@
-"id","field_id/id"
-"","init.c018bfa6-6925-4166-9f84-eda9f63b7e6b"

--- a/distro/configs/odoo/initializer_config/models/ir.model.2000.csv
+++ b/distro/configs/odoo/initializer_config/models/ir.model.2000.csv
@@ -1,3 +1,0 @@
-"id","field_id/id"
-"","init.c018bfa6-6925-4166-9f84-eda9f63b7e6b"
-"","init.44b2048c-34b9-4fe7-90bd-f5296f335c48"

--- a/distro/configs/odoo/initializer_config/models/ir.model.3000.csv
+++ b/distro/configs/odoo/initializer_config/models/ir.model.3000.csv
@@ -1,2 +1,0 @@
-"id","field_id/id"
-"","init.898fe991-aea8-4a9f-8e06-13d796128f94"


### PR DESCRIPTION
https://mekomsolutions.atlassian.net/browse/OZ-962