### PR TITLE
Disable OpenMRS configuration validator from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       java-version: "8"
       maven-phase: "install"
       free-disk-space: true
-      maven-args: "-Pvalidator -Pbundled-docker" # Validate OpenMRS configs & build Docker images embedding the distro bins and configs
+      maven-args: "-Pbundled-docker" # Build Docker images embedding the distro bins and configs (TODO: Add back -Pvalidator when it is fixed)
     secrets:
       NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}


### PR DESCRIPTION
The validator is broken by the addressHierarchy domain and with the `3.5.0` refApp upgrade. We have decided to remove the `-Pvalidator` arg from the CI until a fix is made on the validator module.