### PR TITLE
HIS-19: Add web origins to `account-console` KC client 

### DIFF
--- a/distro/configs/keycloak/realms/ozone-realm.json
+++ b/distro/configs/keycloak/realms/ozone-realm.json
@@ -618,7 +618,9 @@
       "redirectUris": [
         "/realms/ozone/account/*"
       ],
-      "webOrigins": [],
+      "webOrigins": [
+        "+"
+      ],
       "notBefore": 0,
       "bearerOnly": false,
       "consentRequired": false,


### PR DESCRIPTION
Fixes an issue accessing the Accounts page for Ozone users by adding + to the client's web origins which allows only valid redirect urls