### PR TITLE
INFRA-493: Compare dependency reports as part of the build

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -59,8 +59,6 @@
     <analyticsQueriesVersion>1.4.0-SNAPSHOT</analyticsQueriesVersion>
     <analyticsQueriesArtifactId>analytics-queries</analyticsQueriesArtifactId>
 
-    <!-- Classifier for the dependency report artifact -->
-    <dependencyReportClassifier>dependencies</dependencyReportClassifier>
   </properties>
 
   <modules>
@@ -599,28 +597,31 @@
             </goals>
           </execution>
 
-            <!-- Temporary workaround because of AH not loading in Ref App 3.4.0 -->
-            <!-- Flatten addresshierarchy folder structure -->
-            <execution>
-                <id>Flatten OpenMRS Address Hierarchy files</id>
-                <phase>package</phase>
-                <configuration>
-                    <target>
-                        <!-- Copy all files from subfolders into the parent folder -->
-                        <copy todir="${project.build.directory}/${project.artifactId}-${project.version}/configs/openmrs/initializer_config/addresshierarchy" overwrite="true">
-                            <fileset dir="${project.build.directory}/${project.artifactId}-${project.version}/configs/openmrs/initializer_config/addresshierarchy">
-                                <!-- Include all subfolder files -->
-                                <include name="*/**"/>
-                            </fileset>
-                            <!-- flattenmapper removes the subfolder structure -->
-                            <flattenmapper/>
-                        </copy>
-                    </target>
-                </configuration>
-                <goals>
-                    <goal>run</goal>
-                </goals>
-            </execution>
+          <!-- Temporary workaround because of AH not loading in Ref App 3.4.0 -->
+          <!-- Flatten addresshierarchy folder structure -->
+          <execution>
+            <id>Flatten OpenMRS Address Hierarchy files</id>
+            <phase>package</phase>
+            <configuration>
+              <target>
+                <!-- Copy all files from subfolders into the parent folder -->
+                <copy
+                  todir="${project.build.directory}/${project.artifactId}-${project.version}/configs/openmrs/initializer_config/addresshierarchy"
+                  overwrite="true">
+                  <fileset
+                    dir="${project.build.directory}/${project.artifactId}-${project.version}/configs/openmrs/initializer_config/addresshierarchy">
+                    <!-- Include all subfolder files -->
+                    <include name="*/**" />
+                  </fileset>
+                  <!-- flattenmapper removes the subfolder structure -->
+                  <flattenmapper />
+                </copy>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
 
           <execution>
             <id>Remove non-OMODs from Modules</id>
@@ -678,7 +679,7 @@
                 </goals>
             </execution>
 
-            <execution>
+          <execution>
             <id>Copy filtered OpenMRS configuration</id>
             <phase>prepare-package</phase>
             <configuration>
@@ -864,13 +865,16 @@
         </executions>
       </plugin>
 
-      <!-- Compile a dependency report -->
+      <!-- Compile and compare the dependency report -->
       <plugin>
         <groupId>net.mekomsolutions.maven.plugin</groupId>
         <artifactId>dependency-tracker-maven-plugin</artifactId>
+        <configuration>
+          <compare>true</compare>
+        </configuration>
         <executions>
           <execution>
-            <id>Compile dependency report</id>
+            <id>Compile local dependency report and compare with remote</id>
             <phase>compile</phase>
             <goals>
               <goal>track</goal>
@@ -878,7 +882,6 @@
           </execution>
         </executions>
       </plugin>
-
       <!-- Attach the dependency report to the build -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -894,9 +897,10 @@
               <artifacts>
                 <artifact>
                   <file>
-                    ${project.build.directory}/${project.artifactId}-${project.version}-dependencies.txt</file>
+                    ${project.build.directory}/${project.artifactId}-${project.version}-dependencies.txt
+                  </file>
                   <type>txt</type>
-                  <classifier>${dependencyReportClassifier}</classifier>
+                  <classifier>dependencies</classifier>
                 </artifact>
               </artifacts>
             </configuration>

--- a/maven-parent/pom.xml
+++ b/maven-parent/pom.xml
@@ -491,6 +491,49 @@
         </executions>
       </plugin>
 
+      <!-- Compile and compare the dependency report -->
+      <plugin>
+        <groupId>net.mekomsolutions.maven.plugin</groupId>
+        <artifactId>dependency-tracker-maven-plugin</artifactId>
+        <configuration>
+          <compare>true</compare>
+        </configuration>
+        <executions>
+          <execution>
+            <id>Compile local dependency report and compare with remote</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>track</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Attach the dependency report to the build -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>Attach the dependency report</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>
+                    ${project.build.directory}/${project.artifactId}-${project.version}-dependencies.txt
+                  </file>
+                  <type>txt</type>
+                  <classifier>dependencies</classifier>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- packaging the distro as a installable/deployable file -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,6 @@
     <ozoneDistroVersion>1.0.0-SNAPSHOT</ozoneDistroVersion>
     <ozoneDockerComposeVersion>1.0.0-SNAPSHOT</ozoneDockerComposeVersion>
 
-    <!-- Classifier for the dependency report artifact -->
-    <dependencyReportClassifier>dependencies</dependencyReportClassifier>
     <true>true</true>
   </properties>
 
@@ -149,13 +147,16 @@
         </executions>
       </plugin>
 
-      <!-- Compile a dependency report -->
+      <!-- Compile and compare the dependency report -->
       <plugin>
         <groupId>net.mekomsolutions.maven.plugin</groupId>
         <artifactId>dependency-tracker-maven-plugin</artifactId>
+        <configuration>
+          <compare>true</compare>
+        </configuration>
         <executions>
           <execution>
-            <id>Compile dependency report</id>
+            <id>Compile local dependency report and compare with remote</id>
             <phase>compile</phase>
             <goals>
               <goal>track</goal>
@@ -163,13 +164,11 @@
           </execution>
         </executions>
       </plugin>
-
       <!-- Attach the dependency report to the build -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
         <executions>
-
           <execution>
             <id>Attach the dependency report</id>
             <phase>package</phase>
@@ -180,9 +179,10 @@
               <artifacts>
                 <artifact>
                   <file>
-                    ${project.build.directory}/${project.artifactId}-${project.version}-dependencies.txt</file>
+                    ${project.build.directory}/${project.artifactId}-${project.version}-dependencies.txt
+                  </file>
                   <type>txt</type>
-                  <classifier>${dependencyReportClassifier}</classifier>
+                  <classifier>dependencies</classifier>
                 </artifact>
               </artifacts>
             </configuration>


### PR DESCRIPTION
Set the Maven Dependency Tracker to do the comparison of the dependency reports so that CI only has to read the result of this comparison and publish or end.

This is set at the Maven Parent level so that child distros can benefit from it.
This is also set for Ozone Distro project
And the main Ozone as well.

https://mekomsolutions.atlassian.net/browse/INFRA-493